### PR TITLE
Add one more gchoice test

### DIFF
--- a/srfi-221-test.scm
+++ b/srfi-221-test.scm
@@ -98,7 +98,19 @@
       (generator 0 0 0 0 0 1 1 2)
       (generator 1)
       (generator 2)
-      (generator 3))))
+      (generator 3)))
+
+  ;; test exhausted source (choice generator won't be exhausted)
+  (test-g-equal
+   (generator 1 3 5 2 4 6)
+   (gchoice
+    (make-unfold-generator (lambda (_) #f)
+                           (lambda (x) (modulo x 3))
+                           (lambda (x) (+ x 1))
+                           0)
+    (generator 1 2)
+    (generator 3 4)
+    (generator 5 6))))
 
 (test-group
   "generator->stream"


### PR DESCRIPTION
Even if the implementation fails to check the "all sources exhausted" condition, `gchoice` eventually terminates as far as choice generator is finite.

The added test gives an infinite generator to the choice generator argument, so that it can test the implementation properly implements the termination condition.


